### PR TITLE
Resolved NullPointerException causing a blank screen on an ionic app

### DIFF
--- a/android/src/main/java/com/whitestein/securestorage/SecureStoragePlugin.java
+++ b/android/src/main/java/com/whitestein/securestorage/SecureStoragePlugin.java
@@ -39,7 +39,10 @@ public class SecureStoragePlugin extends Plugin {
         String key = call.getString("key");
 
         try {
-            String value = new String(this.passwordStorageHelper.getData(key), Charset.forName("UTF-8"));
+            byte[] data = this.passwordStorageHelper.getData(key);
+            String value = null;
+            if(data != null)
+                value = new String(this.passwordStorageHelper.getData(key), Charset.forName("UTF-8"));
             JSObject ret = new JSObject();
             ret.put("value", value);
             call.success(ret);


### PR DESCRIPTION
The NullPointerException caused a blank and unresponsive screen (after the splash screen) on a Nexus 4 API 27 emulator. This simple change resolved the issue.