### PR TITLE
Remove .always accessibility option from keychain calls

### DIFF
--- a/ios/Plugin/SecureStoragePluginPlugin.swift
+++ b/ios/Plugin/SecureStoragePluginPlugin.swift
@@ -13,7 +13,7 @@ public class SecureStoragePlugin: CAPPlugin {
     @objc func set(_ call: CAPPluginCall) {
         let key = call.getString("key") ?? ""
         let value = call.getString("value") ?? ""
-        let saveSuccessful: Bool = keychainwrapper.set(value, forKey: key, withAccessibility: .always)
+        let saveSuccessful: Bool = keychainwrapper.set(value, forKey: key)
         if(saveSuccessful) {
             call.resolve([
                 "value": saveSuccessful
@@ -33,8 +33,7 @@ public class SecureStoragePlugin: CAPPlugin {
         if (hasValueStandard && !hasValueDedicated) {
             let syncValueSuccessful: Bool = keychainwrapper.set(
                 KeychainWrapper.standard.string(forKey: key) ?? "",
-                forKey: key,
-                withAccessibility: .always
+                forKey: key
             )
             let removeValueSuccessful: Bool = KeychainWrapper.standard.removeObject(forKey: key)
             if (!syncValueSuccessful || !removeValueSuccessful) {

--- a/ios/Plugin/SecureStoragePluginPlugin.swift
+++ b/ios/Plugin/SecureStoragePluginPlugin.swift
@@ -13,7 +13,7 @@ public class SecureStoragePlugin: CAPPlugin {
     @objc func set(_ call: CAPPluginCall) {
         let key = call.getString("key") ?? ""
         let value = call.getString("value") ?? ""
-        let saveSuccessful: Bool = keychainwrapper.set(value, forKey: key)
+        let saveSuccessful: Bool = keychainwrapper.set(value, forKey: key, withAccessibility: .afterFirstUnlock)
         if(saveSuccessful) {
             call.resolve([
                 "value": saveSuccessful
@@ -33,7 +33,8 @@ public class SecureStoragePlugin: CAPPlugin {
         if (hasValueStandard && !hasValueDedicated) {
             let syncValueSuccessful: Bool = keychainwrapper.set(
                 KeychainWrapper.standard.string(forKey: key) ?? "",
-                forKey: key
+                forKey: key,
+                withAccessibility: .afterFirstUnlock
             )
             let removeValueSuccessful: Bool = KeychainWrapper.standard.removeObject(forKey: key)
             if (!syncValueSuccessful || !removeValueSuccessful) {


### PR DESCRIPTION
Issue reference:
https://github.com/martinkasa/capacitor-secure-storage-plugin/issues/54

Remove accessibility option always as the use of .always is deprecated:
`@available(iOS, introduced: 4.0, deprecated: 12.0, message: "Use an accessibility level that provides some user protection, such as kSecAttrAccessibleAfterFirstUnlock")